### PR TITLE
Update jlenv-installer script: v1.0.1 does not exist

### DIFF
--- a/libexec/jlenv-installer
+++ b/libexec/jlenv-installer
@@ -3,7 +3,7 @@
 #
 set -e
 
-tag_name='1.0.1'
+tag_name='1.0.0'
 homebrew=
 type -p brew >/dev/null && homebrew=1
 


### PR DESCRIPTION
jlenv v1.0.1 doesn't exist. This resolves `error: pathspec 'tags/1.0.1' did not match any file(s) known to git` thrown when running `curl -fsSL https://raw.githubusercontent.com/jlenv/jlenv-installer/master/libexec/jlenv-installer | bash`.

Tested only on Kubuntu 18.04.5 using GNU bash 4.4.20(1)-release (x86_64-pc-linux-gnu).